### PR TITLE
added occupational therapist role subclass of institutional health ca…

### DIFF
--- a/src/ontology/rehabo-edit.owl
+++ b/src/ontology/rehabo-edit.owl
@@ -30,6 +30,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0000005>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0000006>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0000007>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0000008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0000009>))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
@@ -183,6 +184,18 @@ AnnotationAssertion(dcterms:created <http://purl.obolibrary.org/obo/REHABO_00000
 AnnotationAssertion(dcterms:creator <http://purl.obolibrary.org/obo/REHABO_0000008> <https://orcid.org/0009-0001-9103-9263>)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/REHABO_0000008> "occupational therapy encounter"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/REHABO_0000008> <http://purl.obolibrary.org/obo/OGMS_0000097>)
+
+# Class: <http://purl.obolibrary.org/obo/REHABO_0000009> (occupational therapist role)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/REHABO_0000009> "An institutional health care role that is created by training and certification in occupational therapy and that is realized by the provision of occupational therapy."@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000117> <http://purl.obolibrary.org/obo/REHABO_0000009> "Manoj Purohit"@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000233> <http://purl.obolibrary.org/obo/REHABO_0000009> <https://github.com/mcwdsi/rehabo/issues/20>)
+AnnotationAssertion(dcterms:contributor <http://purl.obolibrary.org/obo/REHABO_0000009> <https://orcid.org/0000-0002-9881-1017>)
+AnnotationAssertion(dcterms:contributor <http://purl.obolibrary.org/obo/REHABO_0000009> <https://orcid.org/0009-0004-2778-114X>)
+AnnotationAssertion(dcterms:created <http://purl.obolibrary.org/obo/REHABO_0000009> "2026-03-03T03:54:36Z"^^xsd:dateTime)
+AnnotationAssertion(dcterms:creator <http://purl.obolibrary.org/obo/REHABO_0000009> <https://orcid.org/0009-0001-9103-9263>)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/REHABO_0000009> "occupational therapist role"@en)
+SubClassOf(<http://purl.obolibrary.org/obo/REHABO_0000009> <http://purl.obolibrary.org/obo/OMRSE_00000300>)
 
 
 )


### PR DESCRIPTION
Adds occupational therapist role as a subclass of OMRSE: institutional health care provider role (OMRSE:00000300).

Includes:
- rdfs:label
- textual definition (IAO:0000115)

This role inheres in a person who is trained and licensed to provide occupational therapy services.

Fixes #20.