### PR TITLE
Add patient lift (Hoyer lift) as activity of daily living assistive device

### DIFF
--- a/src/ontology/rehabo-edit.owl
+++ b/src/ontology/rehabo-edit.owl
@@ -69,6 +69,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0010024>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0010025>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0010026>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0010027>))
+Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0010028>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0011001>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0011002>))
 Declaration(Class(<http://purl.obolibrary.org/obo/REHABO_0011003>))
@@ -754,6 +755,20 @@ AnnotationAssertion(dcterms:created <http://purl.obolibrary.org/obo/REHABO_00100
 AnnotationAssertion(dcterms:creator <http://purl.obolibrary.org/obo/REHABO_0010027> <https://orcid.org/0009-0001-9103-9263>)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/REHABO_0010027> "requires total personal assistance disposition"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/REHABO_0010027> <http://purl.obolibrary.org/obo/REHABO_0010016>)
+
+# Class: <http://purl.obolibrary.org/obo/REHABO_0010028> (patient lift)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/REHABO_0010028> "An activity of daily living assistive device that uses electrical or hydraulic power to elevate a person above a resting surface and then lower them back down to a resting surface."@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000117> <http://purl.obolibrary.org/obo/REHABO_0010028> "Manoj Purohit"@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000233> <http://purl.obolibrary.org/obo/REHABO_0010028> <https://github.com/mcwdsi/rehabo/discussions/60>)
+AnnotationAssertion(dcterms:contributor <http://purl.obolibrary.org/obo/REHABO_0010028> <https://orcid.org/0000-0002-9881-1017>)
+AnnotationAssertion(dcterms:created <http://purl.obolibrary.org/obo/REHABO_0010028> "2026-08-01T01:25:14Z"^^xsd:dateTime)
+AnnotationAssertion(dcterms:creator <http://purl.obolibrary.org/obo/REHABO_0010028> <https://orcid.org/0009-0001-9103-9263>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/REHABO_0010028> "Hoyer lift"@en)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/REHABO_0010028> "The device is typically used in one or two rooms in a facility."@en)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/REHABO_0010028> "The resting surface is typically a bed, a chair. Typically the person is transferred from one resting surface to another, although nothing prevents raising and lowering with respect to the same surface, for example, to change sheets on the bed."@en)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/REHABO_0010028> "patient lift"@en)
+SubClassOf(<http://purl.obolibrary.org/obo/REHABO_0010028> <http://purl.obolibrary.org/obo/REHABO_0010003>)
 
 # Class: <http://purl.obolibrary.org/obo/REHABO_0011001> (range of motion process)
 


### PR DESCRIPTION
Implements 'patient lift' as proposed in discussion #60 
- patient lift (REHABO:0010028) — subclass of activity of daily living assistive device (REHABO:0010003)
- has narrow synonym: Hoyer lift
